### PR TITLE
Aps migration and small refactor

### DIFF
--- a/app/Console/Commands/ArubaSyncControllers.php
+++ b/app/Console/Commands/ArubaSyncControllers.php
@@ -55,15 +55,6 @@ class ArubaSyncControllers extends Command
      */
     private $debug;
     
-    public function __construct()
-    {
-      $aps = Aps::all();
-      if ($aps) {
-        $this->aps = array_map_by_key($aps->toArray(), 'ap_name');
-      }
-      parent::__construct();
-    }
-    
     /**
       * Get the console command arguments.
       *
@@ -85,7 +76,12 @@ class ArubaSyncControllers extends Command
      */
     public function handle()
     { 
-      
+      if (!$this->aps) {
+        $aps = Aps::all();
+        if ($aps) {
+          $this->aps = array_map_by_key($aps->toArray(), 'ap_name');
+        }
+      }
       //\Artisan::call('aruba:sync:controllers', ['school_id' => \Shelter::getID(), 'no_debug' => 1, 'force' => 1]);
       
       //*** Debug ***

--- a/database/migrations/2019_11_25_115603_create_aps_table.php
+++ b/database/migrations/2019_11_25_115603_create_aps_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateApsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+	{
+		Schema::create('aps', function(Blueprint $table)
+		{
+			$table->increments('id');
+			$table->integer('school_id');
+			$table->integer('floor_id');
+            $table->string('ap_ale_id', 50);
+            $table->string('ap_ale_name', 255);
+            $table->string('mac_address', 255);
+			$table->float('x', 10, 3);
+			$table->float('y', 10, 3);
+		});
+	}
+
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::drop('aps');
+	}
+}


### PR DESCRIPTION
* Adds `aps` table
* Loads Aps in `handle()`, not in `__construct()`